### PR TITLE
fix: wrap preset in a function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,4 +26,4 @@ for (const [name, cases] of Object.entries(tests)) {
   }
 }
 
-module.exports = { plugins };
+module.exports = () => ({ plugins });


### PR DESCRIPTION
I was getting `Plugin/Preset files are not allowed to export objects, only functions.` when using this preset