### PR TITLE
update package.json repository to follow documented format

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.2",
   "description": "A Babel preset that enables parsing of proposals supported by the current Node.js version.",
   "main": "src/index.js",
-  "repository": "https://github.com/nicolo-ribaudo/babel-preset-current-node-syntax",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nicolo-ribaudo/babel-preset-current-node-syntax.git"
+  },
   "author": {
     "name": "Nicolò Ribaudo",
     "url": "https://github.com/nicolo-ribaudo"


### PR DESCRIPTION
Update the `repository` field in **package.json** to follow [the documentation](https://docs.npmjs.com/files/package.json#repository).

This is a problem because the project's page on https://www.npmjs.com/package/babel-preset-current-node-syntax doesn't include a link to the repo.